### PR TITLE
[FEAT]: 로그인, 회원가입 구현

### DIFF
--- a/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/AuthController.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/AuthController.kt
@@ -53,7 +53,7 @@ class AuthController (
     @PostMapping("/logout")
     @Auth
     fun logout(@MemberID memberId: Long?): ResponseEntity<ApiResponse<Any>> {
-        if (memberId != null) {
+        if (memberId != null) { /* TODO : memberId가 왜 NULL 인가 */
             commonAuthService.logout(memberId)
         }
         log.info { "로그아웃 완료. memberId: $memberId" }

--- a/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/AuthController.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/AuthController.kt
@@ -2,7 +2,9 @@ package coinkiri.api.controller.auth
 
 import coinkiri.api.config.interceptor.Auth
 import coinkiri.api.config.resolver.MemberID
+import coinkiri.api.controller.auth.dto.request.LoginRequestDto
 import coinkiri.api.controller.auth.dto.request.SignupRequestDto
+import coinkiri.api.controller.auth.dto.response.TokenResponseDto
 import coinkiri.api.service.auth.AuthServiceProvider
 import coinkiri.api.service.auth.CommonAuthService
 import coinkiri.api.service.auth.jwt.TokenService
@@ -11,6 +13,7 @@ import coinkiri.common.response.ApiResponse
 import coinkiri.core.domain.member.SocialType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -27,11 +30,22 @@ class AuthController (
 ){
     @Operation(summary = "소셜 회원가입")
     @PostMapping("/signup")
-    fun signup(@RequestBody request: SignupRequestDto): ResponseEntity<ApiResponse<Any>> {
+    fun signup(@RequestBody request: SignupRequestDto): ResponseEntity<ApiResponse<TokenResponseDto>> {
         val authService = authServiceProvider.getAuthService(SocialType.valueOf(request.socialType))
         val memberId = authService.signup(request)
         val jwtToken = tokenService.createTokenInfo(memberId)
         log.info { "소셜 회원가입 완료. memberId: $memberId, jwtToken: $jwtToken" }
+        return ResponseEntity.ok(ApiResponse.success(jwtToken))
+    }
+
+    // 안씀
+    @Operation(summary = "소셜 로그인")
+    @PostMapping("/login")
+    fun login(@RequestBody request: LoginRequestDto): ResponseEntity<ApiResponse<TokenResponseDto>> {
+        val authService = authServiceProvider.getAuthService(SocialType.valueOf(request.socialType))
+        val memberId = authService.login(request)
+        val jwtToken = tokenService.createTokenInfo(memberId)
+        log.info { "소셜 로그인 완료. memberId: $memberId, tokenInfo: $jwtToken" }
         return ResponseEntity.ok(ApiResponse.success(jwtToken))
     }
 

--- a/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/dto/request/LoginRequestDto.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/controller/auth/dto/request/LoginRequestDto.kt
@@ -1,0 +1,7 @@
+package coinkiri.api.controller.auth.dto.request
+
+
+class LoginRequestDto (
+    val token: String, // 소셜 토큰
+    val socialType: String, // 소셜 로그인 타입
+)

--- a/coinkiri-api/src/main/kotlin/coinkiri/api/service/auth/AuthService.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/service/auth/AuthService.kt
@@ -1,11 +1,12 @@
 package coinkiri.api.service.auth
 
+import coinkiri.api.controller.auth.dto.request.LoginRequestDto
 import coinkiri.api.controller.auth.dto.request.SignupRequestDto
 
 interface AuthService {
 
     fun signup(request: SignupRequestDto): Long
 
-
+    fun login(request: LoginRequestDto): Long
 
 }

--- a/coinkiri-api/src/main/kotlin/coinkiri/api/service/auth/KakaoAuthService.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/service/auth/KakaoAuthService.kt
@@ -1,6 +1,7 @@
 package coinkiri.api.service.auth
 
 import coinkiri.api.client.kakao.KakaoApiCaller
+import coinkiri.api.controller.auth.dto.request.LoginRequestDto
 import coinkiri.api.controller.auth.dto.request.SignupRequestDto
 import coinkiri.api.service.member.MemberService
 import coinkiri.core.domain.member.SocialType
@@ -21,5 +22,11 @@ class KakaoAuthService (
     override fun signup(request: SignupRequestDto): Long {
         val response = kakaoApiCaller.getProfileInfo(request.token)
         return memberService.registerUser(request.toRegisterRequestDto(response.id))
+    }
+
+    @Transactional
+    override fun login(request: LoginRequestDto): Long {
+        val response = kakaoApiCaller.getProfileInfo(request.token)
+        return memberService.login(response.id, socialType)
     }
 }

--- a/coinkiri-api/src/main/kotlin/coinkiri/api/service/member/MemberService.kt
+++ b/coinkiri-api/src/main/kotlin/coinkiri/api/service/member/MemberService.kt
@@ -2,6 +2,7 @@ package coinkiri.api.service.member
 
 import coinkiri.api.controller.member.dto.request.RegisterRequestDto
 import coinkiri.api.controller.member.dto.response.MemberInfoDto
+import coinkiri.core.domain.member.SocialType
 import coinkiri.core.domain.member.repository.MemberRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,13 +15,17 @@ class MemberService (
     // 회원 정보 저장 API - new
     @Transactional
     fun registerUser(request: RegisterRequestDto): Long {
-        if (memberRepository.existsBySocialId(request.socialId)) { // 소셜 아이디 중복 체크
-            throw IllegalArgumentException("이미 존재하는 소셜 아이디입니다.")
-        }
-        val member = memberRepository.save(request.toEntity())
-        return member.id!! // 회원 정보 저장 후 회원 ID 반환
+        // 소셜 아이디로 회원 조회 후 있으면 ID 반환, 없으면 회원 저장 후 ID 반환
+        return memberRepository.findBySocialId(request.socialId)?.id ?: memberRepository.save(request.toEntity()).id!!
     }
 
+
+    // 회원 로그인 API
+    @Transactional
+    fun login(socialId: String, socialType: SocialType): Long {
+        val member = memberRepository.findBySocialIdAndSocialType(socialId, socialType) ?: throw IllegalArgumentException("존재하지 않는 유저입니다.")
+        return member.id!! // 회원 ID 반환
+    }
 
     // 회원 정보 저장 API
     @Transactional
@@ -30,6 +35,7 @@ class MemberService (
         }
         memberRepository.save(request.toEntity()) // 회원 정보 저장
     }
+
 
     // 회원 확인 API
     @Transactional(readOnly = true)

--- a/coinkiri-core/src/main/kotlin/coinkiri/core/domain/member/repository/MemberRepository.java
+++ b/coinkiri-core/src/main/kotlin/coinkiri/core/domain/member/repository/MemberRepository.java
@@ -3,11 +3,13 @@ package coinkiri.core.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import coinkiri.core.domain.member.Member;
-
+import coinkiri.core.domain.member.SocialType;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Member findBySocialId(String socialId); // 소셜 id로 사용자 조회
 
 	boolean existsBySocialId(String socialId); // 소셜 id로 사용자 존재 여부 조회
+
+	Member findBySocialIdAndSocialType(String socialId, SocialType socialType); // 소셜 id와 소셜 타입으로 사용자 조회
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #10 

## 🔑 Key Changes

1. signup api 하나로 회원이 있으면 있는 걸 반환, 없으면 저장 후 반환 하도록 구현

## 📸 Screenshot


## 📢 To Reviewers
-

